### PR TITLE
Clarify project scripts and quick start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+npm-debug.log*
+*.log

--- a/index.html
+++ b/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kinetiq Demo</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        background: #0f0f0f;
+        color: #f1f5f9;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+        align-items: center;
+      }
+      header.top-bar {
+        width: 100%;
+        max-width: 1100px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 12px 20px;
+        background: rgba(12, 12, 12, 0.8);
+        border-bottom: 2px solid #111827;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+      }
+      main.canvas-wrapper {
+        flex: 1;
+        width: 100%;
+        max-width: 1100px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 12px;
+      }
+      canvas {
+        background: #050505;
+        width: min(900px, 100%);
+        height: auto;
+        aspect-ratio: 1 / 1;
+        border: 2px solid #111827;
+        image-rendering: pixelated;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="top-bar">
+      <div class="title">Kinetiq</div>
+      <div class="versus">Devil VS Unarmed</div>
+    </header>
+    <main class="canvas-wrapper">
+      <canvas id="gameCanvas" width="900" height="900"></canvas>
+    </main>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,957 @@
+{
+  "name": "ball-fight",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ball-fight",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.4.0",
+        "vite": "^5.1.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ball-fight",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "start": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "npm run build"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vite": "^5.1.0"
+  }
+}

--- a/readme
+++ b/readme
@@ -1,77 +1,45 @@
-Kinetiq (Work in Progress)
+Kinetiq
+=======
 
-Kinetiq is a physics-driven auto-battler where circular fighters bounce around an arena with rotating melee arms. Players don’t control the fighters — battles resolve automatically through physics, collisions, and damage systems.
+Kinetiq is a physics-driven two-ball auto-battler. Two circular fighters bounce around a square arena with rotating melee arms, chip away each other’s HP with direct hits and DoT packets, and finish the round without any player input.
 
-Concept
+Quick start
+-----------
 
-Arena: A rectangular box where fighters bounce around.
+```bash
+npm install
+npm run dev
+```
 
-Fighters: Spherical units with HP, unique stats, and a rotating arm/weapon.
+The development server prints a local URL (default `http://localhost:5173`) that streams the canvas simulation. To build a production bundle or run the automated build check, use:
 
-Combat: Damage is applied when a weapon collides with an opponent. Special effects like burn (damage over time) or shields (damage reduction) can apply.
+```bash
+npm run build
+```
 
-Win Condition: The match ends when one fighter’s HP reaches zero.
+If you prefer the more traditional `npm start` or need a simple success/fail script, the project also exposes:
 
-Planned Features
+```bash
+npm start    # alias of npm run dev
+npm test     # runs the build pipeline
+```
 
-Physics simulation (elastic wall + ball collisions, rotating arms).
+Gameplay overview
+-----------------
 
-Damage system:
+- **Arena** – 760×760 fighting space with rigid black borders inside a 900×900 canvas.
+- **Fighters** – Data-driven stat blocks (HP, damage, burn DoT, shield reduction, etc.). Each fighter has a rotating arm with a circular weapon head.
+- **Combat** – Weapon overlaps inflict base + hellfire damage, apply burn DoTs, and trigger shield mitigation. Direct body collisions optionally add a demon damage graze.
+- **Damage over time** – Burn timers tick independently, refreshing when new hellfire hits land.
+- **Win condition** – The match freezes when one fighter’s HP reaches zero. Press **R** (or click the on-screen restart button) to reset with new random velocities.
 
-Base damage
+Project structure
+-----------------
 
-Bonus damage (e.g., Hellfire)
+- `index.html` – Canvas shell with the top title bar.
+- `src/main.ts` – Entry point that wires the deterministic simulation loop to rendering.
+- `src/types.ts` – Shared data types and fighter stat definitions.
+- `src/game.ts` – Physics integration, collisions, damage application, DoT handling, win logic.
+- `src/ui.ts` – Canvas drawing routines for the arena, fighters, burn/shield effects, stat panel, and restart affordances.
 
-Burn damage over time
-
-Shield % reduction
-
-Data-driven fighter definitions (JSON/TS objects).
-
-On-screen UI:
-
-Fighter names
-
-Current HP displayed on each ball
-
-Stat panel at the bottom
-
-Restart button to re-run matches.
-
-Tech Stack
-
-Language: TypeScript
-
-Rendering: HTML5 Canvas
-
-Bundler: Vite
-
-No external game engine — physics and combat written from scratch.
-
-Project Goals
-
-Recreate the look and feel of the original “Kinetiq” prototype.
-
-Keep systems modular so new fighters can be added easily.
-
-Use this as a base for experimenting with AI-assisted game dev (Cursor/Codex prompts).
-
-Roadmap
-
-Setup Vite + TS project structure
-
-Implement arena + ball physics
-
-Add rotating arms and collision detection
-
-Implement combat (damage, burn, shield)
-
-UI overlay for stats and HP
-
-Win state + restart logic
-
-Add more fighter presets
-
-Status
-
-🚧 Not yet implemented. This README documents the vision and intended direction.
+The codebase is intentionally framework-light: plain TypeScript, HTML5 Canvas, and Vite for bundling.

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,0 +1,408 @@
+import {
+  ArenaBounds,
+  BurnState,
+  FighterInstance,
+  FighterState,
+  FighterStats,
+  GameRenderState,
+  Vector2
+} from "./types";
+
+export const CANVAS_SIZE = 900;
+export const ARENA_SIZE = 760;
+export const ARENA_PADDING = (CANVAS_SIZE - ARENA_SIZE) / 2;
+
+export const DEVIL: FighterStats = {
+  name: "Devil",
+  maxHP: 500,
+  baseDamage: 5,
+  hellfireDamage: 10,
+  burnPerTick: 2,
+  burnTickMs: 400,
+  burnDurationMs: 3000,
+  demonDamage: 1,
+  shieldPct: 0.3,
+  speedMultiplier: 1.0,
+  damageMultiplier: 1.0,
+  radius: 36,
+  arm: { length: 60, radius: 10, angularSpeed: 2.4 },
+  colors: { body: "#4c0b0b", ring: "#2b0000", text: "#00ff00" }
+};
+
+export const UNARMED: FighterStats = {
+  name: "Unarmed",
+  maxHP: 250,
+  baseDamage: 4,
+  hellfireDamage: 0,
+  burnPerTick: 0,
+  burnTickMs: 0,
+  burnDurationMs: 0,
+  demonDamage: 0,
+  shieldPct: 0,
+  speedMultiplier: 1.0,
+  damageMultiplier: 1.0,
+  radius: 28,
+  arm: { length: 45, radius: 8, angularSpeed: 2.0 },
+  colors: { body: "#9aa0a6", ring: "#6b7280", text: "#00ff00" }
+};
+
+const TWO_PI = Math.PI * 2;
+const BASE_SPEED = 140;
+
+const MASS_SCALE = 0.5; // used to derive pseudo-mass from radius for impulse calculations
+const KNOCKBACK_STRENGTH = 0.6;
+
+function createArena(): ArenaBounds {
+  return {
+    minX: ARENA_PADDING,
+    maxX: CANVAS_SIZE - ARENA_PADDING,
+    minY: ARENA_PADDING,
+    maxY: CANVAS_SIZE - ARENA_PADDING
+  };
+}
+
+function cloneVector(v: Vector2): Vector2 {
+  return { x: v.x, y: v.y };
+}
+
+function subtract(a: Vector2, b: Vector2): Vector2 {
+  return { x: a.x - b.x, y: a.y - b.y };
+}
+
+function add(a: Vector2, b: Vector2): Vector2 {
+  return { x: a.x + b.x, y: a.y + b.y };
+}
+
+function multiply(v: Vector2, scalar: number): Vector2 {
+  return { x: v.x * scalar, y: v.y * scalar };
+}
+
+function length(v: Vector2): number {
+  return Math.hypot(v.x, v.y);
+}
+
+function normalize(v: Vector2): Vector2 {
+  const len = length(v);
+  if (len === 0) {
+    return { x: 0, y: 0 };
+  }
+  return { x: v.x / len, y: v.y / len };
+}
+
+function dot(a: Vector2, b: Vector2): number {
+  return a.x * b.x + a.y * b.y;
+}
+
+function deriveMass(radius: number): number {
+  return Math.max(1, radius * radius * MASS_SCALE);
+}
+
+function randomAngle(rng: () => number, towards: number): number {
+  const spread = Math.PI / 2; // 90 degree cone
+  return towards + (rng() - 0.5) * spread;
+}
+
+function makeVelocity(stats: FighterStats, rng: () => number, facing: number): Vector2 {
+  const angle = randomAngle(rng, facing);
+  const speed = BASE_SPEED * stats.speedMultiplier;
+  return {
+    x: Math.cos(angle) * speed,
+    y: Math.sin(angle) * speed
+  };
+}
+
+function createFighter(id: number, stats: FighterStats, position: Vector2, rng: () => number): FighterInstance {
+  const velocity = makeVelocity(stats, rng, id === 0 ? 0 : Math.PI);
+  const state: FighterState = {
+    position: cloneVector(position),
+    velocity,
+    armAngle: rng() * TWO_PI,
+    hp: stats.maxHP,
+    weaponCollidingWith: new Set<number>(),
+    bodyCollidingWith: new Set<number>()
+  };
+  return { id, stats, state };
+}
+
+export function getWeaponHeadPosition(fighter: FighterInstance): Vector2 {
+  const { state, stats } = fighter;
+  const dx = Math.cos(state.armAngle) * stats.arm.length;
+  const dy = Math.sin(state.armAngle) * stats.arm.length;
+  return {
+    x: state.position.x + dx,
+    y: state.position.y + dy
+  };
+}
+
+export class Game {
+  private arena: ArenaBounds;
+  private fighters: FighterInstance[];
+  private rng: () => number;
+  private finished = false;
+  private winnerName?: string;
+
+  constructor(rng?: () => number) {
+    this.rng = rng ?? Math.random;
+    this.arena = createArena();
+    this.fighters = [];
+    this.reset();
+  }
+
+  reset(): void {
+    const center = CANVAS_SIZE / 2;
+    const horizontalOffset = ARENA_SIZE / 4;
+    this.arena = createArena();
+    this.finished = false;
+    this.winnerName = undefined;
+
+    this.fighters = [
+      createFighter(0, DEVIL, { x: center - horizontalOffset, y: center }, this.rng),
+      createFighter(1, UNARMED, { x: center + horizontalOffset, y: center }, this.rng)
+    ];
+  }
+
+  update(dtSeconds: number): void {
+    if (this.finished) {
+      return;
+    }
+
+    const dtMs = dtSeconds * 1000;
+
+    for (const fighter of this.fighters) {
+      this.integrateMotion(fighter, dtSeconds);
+      this.wrapArmAngle(fighter, dtSeconds);
+      this.resolveWallCollisions(fighter);
+    }
+
+    this.resolveFighterCollisions();
+    this.resolveWeaponHits();
+
+    for (const fighter of this.fighters) {
+      this.tickBurn(fighter, dtMs);
+    }
+
+    this.checkForWinner();
+  }
+
+  getRenderState(): GameRenderState {
+    return {
+      fighters: this.fighters,
+      arena: this.arena,
+      isFinished: this.finished,
+      winnerName: this.winnerName
+    };
+  }
+
+  private integrateMotion(fighter: FighterInstance, dt: number): void {
+    const { state } = fighter;
+    state.position.x += state.velocity.x * dt;
+    state.position.y += state.velocity.y * dt;
+    const dampingFactor = Math.max(0, 1 - 0.1 * dt);
+    state.velocity.x *= dampingFactor;
+    state.velocity.y *= dampingFactor;
+  }
+
+  private wrapArmAngle(fighter: FighterInstance, dt: number): void {
+    const { state, stats } = fighter;
+    state.armAngle += stats.arm.angularSpeed * dt;
+    state.armAngle = (state.armAngle + TWO_PI) % TWO_PI;
+  }
+
+  private resolveWallCollisions(fighter: FighterInstance): void {
+    const { state, stats } = fighter;
+    const minX = this.arena.minX + stats.radius;
+    const maxX = this.arena.maxX - stats.radius;
+    const minY = this.arena.minY + stats.radius;
+    const maxY = this.arena.maxY - stats.radius;
+
+    if (state.position.x < minX) {
+      state.position.x = minX;
+      state.velocity.x = Math.abs(state.velocity.x);
+    } else if (state.position.x > maxX) {
+      state.position.x = maxX;
+      state.velocity.x = -Math.abs(state.velocity.x);
+    }
+
+    if (state.position.y < minY) {
+      state.position.y = minY;
+      state.velocity.y = Math.abs(state.velocity.y);
+    } else if (state.position.y > maxY) {
+      state.position.y = maxY;
+      state.velocity.y = -Math.abs(state.velocity.y);
+    }
+  }
+
+  private resolveFighterCollisions(): void {
+    const [a, b] = this.fighters;
+    const diff = subtract(a.state.position, b.state.position);
+    const distance = length(diff);
+    const minDistance = a.stats.radius + b.stats.radius;
+
+    if (distance === 0) {
+      diff.x = 1;
+      diff.y = 0;
+    }
+
+    if (distance < minDistance) {
+      const normal = normalize(diff);
+      const penetration = minDistance - distance;
+      const correction = multiply(normal, penetration / 2);
+      a.state.position.x += correction.x;
+      a.state.position.y += correction.y;
+      b.state.position.x -= correction.x;
+      b.state.position.y -= correction.y;
+
+      const relativeVelocity = subtract(a.state.velocity, b.state.velocity);
+      const velAlongNormal = dot(relativeVelocity, normal);
+
+      if (velAlongNormal < 0) {
+        const restitution = 1; // perfectly elastic
+        const massA = deriveMass(a.stats.radius);
+        const massB = deriveMass(b.stats.radius);
+        const impulseScalar = (-(1 + restitution) * velAlongNormal) / (1 / massA + 1 / massB);
+        const impulse = multiply(normal, impulseScalar);
+        a.state.velocity = add(a.state.velocity, multiply(impulse, 1 / massA));
+        b.state.velocity = subtract(b.state.velocity, multiply(impulse, 1 / massB));
+      }
+
+      if (!a.state.bodyCollidingWith.has(b.id)) {
+        this.handleBodyGraze(a, b);
+      }
+      a.state.bodyCollidingWith.add(b.id);
+      b.state.bodyCollidingWith.add(a.id);
+    } else {
+      a.state.bodyCollidingWith.delete(b.id);
+      b.state.bodyCollidingWith.delete(a.id);
+    }
+  }
+
+  private resolveWeaponHits(): void {
+    const [a, b] = this.fighters;
+    this.processWeaponHit(a, b);
+    this.processWeaponHit(b, a);
+  }
+
+  private processWeaponHit(attacker: FighterInstance, defender: FighterInstance): void {
+    const weaponPos = getWeaponHeadPosition(attacker);
+    const toDefender = subtract(weaponPos, defender.state.position);
+    const distanceSq = dot(toDefender, toDefender);
+    const reach = attacker.stats.arm.radius + defender.stats.radius;
+
+    if (distanceSq <= reach * reach) {
+      if (!attacker.state.weaponCollidingWith.has(defender.id)) {
+        this.handleWeaponImpact(attacker, defender, weaponPos);
+      }
+      attacker.state.weaponCollidingWith.add(defender.id);
+    } else {
+      attacker.state.weaponCollidingWith.delete(defender.id);
+    }
+  }
+
+  private handleWeaponImpact(attacker: FighterInstance, defender: FighterInstance, weaponPos: Vector2): void {
+    const basePacket = (attacker.stats.baseDamage + attacker.stats.hellfireDamage) * attacker.stats.damageMultiplier;
+    this.applyDamage(attacker, defender, basePacket, "weapon");
+    this.applyBurn(attacker, defender);
+    this.applyKnockback(attacker, defender);
+  }
+
+  private handleBodyGraze(a: FighterInstance, b: FighterInstance): void {
+    const damageA = a.stats.demonDamage * a.stats.damageMultiplier;
+    const damageB = b.stats.demonDamage * b.stats.damageMultiplier;
+    if (damageA > 0) {
+      this.applyDamage(a, b, damageA, "demon");
+    }
+    if (damageB > 0) {
+      this.applyDamage(b, a, damageB, "demon");
+    }
+  }
+
+  private applyDamage(attacker: FighterInstance, defender: FighterInstance, amount: number, source: "weapon" | "burn" | "demon"): void {
+    if (amount <= 0 || defender.state.hp <= 0) {
+      return;
+    }
+    const mitigated = amount * (1 - defender.stats.shieldPct);
+    if (mitigated <= 0) {
+      return;
+    }
+    defender.state.hp = Math.max(0, defender.state.hp - mitigated);
+  }
+
+  private applyBurn(attacker: FighterInstance, defender: FighterInstance): void {
+    const { burnPerTick, burnDurationMs, burnTickMs, damageMultiplier } = attacker.stats;
+    if (burnPerTick <= 0 || burnDurationMs <= 0 || burnTickMs <= 0) {
+      return;
+    }
+    const burn: BurnState = {
+      remainingMs: burnDurationMs,
+      tickTimer: burnTickMs,
+      baseTickDamage: burnPerTick * damageMultiplier,
+      sourceId: attacker.id,
+      tickInterval: burnTickMs
+    };
+    defender.state.burn = burn;
+  }
+
+  private tickBurn(target: FighterInstance, dtMs: number): void {
+    const burn = target.state.burn;
+    if (!burn) {
+      return;
+    }
+    burn.remainingMs -= dtMs;
+    burn.tickTimer -= dtMs;
+
+    const source = this.fighters.find((f) => f.id === burn.sourceId) ?? target;
+
+    while (burn.remainingMs > 0 && burn.tickTimer <= 0) {
+      this.applyDamage(source, target, burn.baseTickDamage, "burn");
+      burn.tickTimer += burn.tickInterval;
+    }
+
+    if (burn.remainingMs <= 0) {
+      target.state.burn = undefined;
+    }
+  }
+
+  private applyKnockback(attacker: FighterInstance, defender: FighterInstance): void {
+    const tangent = this.getWeaponTangent(attacker);
+    const armTipSpeed = Math.abs(attacker.stats.arm.angularSpeed) * attacker.stats.arm.length;
+    const armVelocity = multiply(tangent, armTipSpeed);
+    const relative = subtract(add(attacker.state.velocity, armVelocity), defender.state.velocity);
+    const relAlongTangent = dot(relative, tangent);
+    const impulseMagnitude = relAlongTangent * KNOCKBACK_STRENGTH;
+    if (impulseMagnitude === 0) {
+      return;
+    }
+    const massAttacker = deriveMass(attacker.stats.radius);
+    const massDefender = deriveMass(defender.stats.radius);
+    const impulse = multiply(tangent, impulseMagnitude);
+    defender.state.velocity = add(defender.state.velocity, multiply(impulse, 1 / massDefender));
+    attacker.state.velocity = subtract(attacker.state.velocity, multiply(impulse, 1 / massAttacker));
+  }
+
+  private getWeaponTangent(fighter: FighterInstance): Vector2 {
+    const { state, stats } = fighter;
+    const tangent = {
+      x: -Math.sin(state.armAngle),
+      y: Math.cos(state.armAngle)
+    };
+    if (stats.arm.angularSpeed < 0) {
+      tangent.x *= -1;
+      tangent.y *= -1;
+    }
+    return normalize(tangent);
+  }
+
+  private checkForWinner(): void {
+    const alive = this.fighters.filter((f) => f.state.hp > 0);
+    if (alive.length === 2) {
+      return;
+    }
+
+    this.finished = true;
+    if (alive.length === 1) {
+      this.winnerName = alive[0].stats.name;
+    } else {
+      this.winnerName = "Draw";
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,57 @@
+import { Game, CANVAS_SIZE } from "./game";
+import { renderGame } from "./ui";
+
+const canvasElement = document.getElementById("gameCanvas");
+if (!(canvasElement instanceof HTMLCanvasElement)) {
+  throw new Error("Canvas element #gameCanvas not found");
+}
+const canvas = canvasElement;
+const context = canvas.getContext("2d");
+if (!context) {
+  throw new Error("2D rendering context not available");
+}
+const ctx = context;
+
+ctx.imageSmoothingEnabled = true;
+
+const game = new Game();
+const FIXED_STEP = 1 / 120;
+const MAX_DELTA = 0.1; // prevent spiral of death from long frames
+let accumulator = 0;
+let lastTime = performance.now();
+
+function updateLoop(time: number): void {
+  const deltaSeconds = Math.min((time - lastTime) / 1000, MAX_DELTA);
+  lastTime = time;
+  accumulator += deltaSeconds;
+
+  while (accumulator >= FIXED_STEP) {
+    game.update(FIXED_STEP);
+    accumulator -= FIXED_STEP;
+  }
+
+  renderGame(ctx, game.getRenderState());
+  requestAnimationFrame(updateLoop);
+}
+
+function resizeCanvas(): void {
+  const header = document.querySelector(".top-bar") as HTMLElement | null;
+  const headerHeight = header?.offsetHeight ?? 0;
+  const availableHeight = Math.max(200, window.innerHeight - headerHeight);
+  const availableWidth = Math.max(200, window.innerWidth);
+  const scale = Math.min(1, availableWidth / CANVAS_SIZE, availableHeight / CANVAS_SIZE);
+  const cssSize = CANVAS_SIZE * scale;
+  canvas.style.width = `${cssSize}px`;
+  canvas.style.height = `${cssSize}px`;
+}
+
+window.addEventListener("resize", resizeCanvas);
+resizeCanvas();
+
+window.addEventListener("keydown", (event) => {
+  if (event.key.toLowerCase() === "r") {
+    game.reset();
+  }
+});
+
+requestAnimationFrame(updateLoop);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,78 @@
+export interface Vector2 {
+  x: number;
+  y: number;
+}
+
+export interface ArmStats {
+  length: number;
+  radius: number;
+  angularSpeed: number; // radians per second
+}
+
+export interface FighterColors {
+  body: string;
+  ring: string;
+  text: string;
+}
+
+export interface FighterStats {
+  name: string;
+  maxHP: number;
+  baseDamage: number;
+  hellfireDamage: number;
+  burnPerTick: number;
+  burnTickMs: number;
+  burnDurationMs: number;
+  demonDamage: number;
+  shieldPct: number;
+  speedMultiplier: number;
+  damageMultiplier: number;
+  radius: number;
+  arm: ArmStats;
+  colors: FighterColors;
+}
+
+export interface BurnState {
+  remainingMs: number;
+  tickTimer: number;
+  baseTickDamage: number;
+  sourceId: number;
+  tickInterval: number;
+}
+
+export interface FighterState {
+  position: Vector2;
+  velocity: Vector2;
+  armAngle: number;
+  hp: number;
+  burn?: BurnState;
+  weaponCollidingWith: Set<number>;
+  bodyCollidingWith: Set<number>;
+}
+
+export interface FighterInstance {
+  id: number;
+  stats: FighterStats;
+  state: FighterState;
+}
+
+export interface ArenaBounds {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
+export interface DamageContext {
+  attacker: FighterInstance;
+  defender: FighterInstance;
+  amount: number;
+  source: "weapon" | "burn" | "demon";
+}
+
+export interface GameRenderState {
+  fighters: FighterInstance[];
+  arena: ArenaBounds;
+  isFinished: boolean;
+  winnerName?: string;
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,0 +1,203 @@
+import { ARENA_PADDING, ARENA_SIZE, CANVAS_SIZE, getWeaponHeadPosition } from "./game";
+import { FighterInstance, GameRenderState } from "./types";
+
+const BOTTOM_PANEL_HEIGHT = 120;
+const ARENA_BACKGROUND = "#111827";
+const ARENA_BORDER = "#000000";
+const PANEL_BACKGROUND = "rgba(15, 23, 42, 0.9)";
+const PANEL_TEXT = "#e2e8f0";
+const HP_FONT = "bold 22px 'Orbitron', 'Segoe UI', sans-serif";
+const LABEL_FONT = "600 20px 'Orbitron', 'Segoe UI', sans-serif";
+const PANEL_FONT = "500 16px 'Segoe UI', sans-serif";
+const WINNER_FONT = "700 42px 'Orbitron', 'Segoe UI', sans-serif";
+
+export function renderGame(ctx: CanvasRenderingContext2D, state: GameRenderState): void {
+  ctx.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+  drawBackground(ctx);
+  drawArena(ctx);
+  drawTopLabels(ctx, state);
+
+  for (const fighter of state.fighters) {
+    drawShield(ctx, fighter);
+  }
+
+  for (const fighter of state.fighters) {
+    drawBurnAura(ctx, fighter);
+    drawFighterBody(ctx, fighter);
+    drawArm(ctx, fighter);
+    drawHP(ctx, fighter);
+  }
+
+  drawBottomPanel(ctx, state.fighters);
+
+  if (state.isFinished && state.winnerName) {
+    drawWinnerText(ctx, state.winnerName);
+  }
+}
+
+function drawBackground(ctx: CanvasRenderingContext2D): void {
+  ctx.save();
+  ctx.fillStyle = "#020617";
+  ctx.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+  ctx.restore();
+}
+
+function drawArena(ctx: CanvasRenderingContext2D): void {
+  ctx.save();
+  ctx.fillStyle = ARENA_BACKGROUND;
+  ctx.fillRect(ARENA_PADDING, ARENA_PADDING, ARENA_SIZE, ARENA_SIZE);
+  ctx.lineWidth = 8;
+  ctx.strokeStyle = ARENA_BORDER;
+  ctx.strokeRect(ARENA_PADDING, ARENA_PADDING, ARENA_SIZE, ARENA_SIZE);
+  ctx.restore();
+}
+
+function drawTopLabels(ctx: CanvasRenderingContext2D, state: GameRenderState): void {
+  const label = `${state.fighters[0].stats.name} VS ${state.fighters[1].stats.name}`;
+  ctx.save();
+  ctx.fillStyle = "#f8fafc";
+  ctx.font = LABEL_FONT;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "bottom";
+  ctx.fillText(label, CANVAS_SIZE / 2, ARENA_PADDING - 16);
+  ctx.restore();
+}
+
+function drawFighterBody(ctx: CanvasRenderingContext2D, fighter: FighterInstance): void {
+  const { position } = fighter.state;
+  const { radius, colors } = fighter.stats;
+  ctx.save();
+  ctx.fillStyle = colors.body;
+  ctx.strokeStyle = colors.ring;
+  ctx.lineWidth = 6;
+  ctx.beginPath();
+  ctx.arc(position.x, position.y, radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawArm(ctx: CanvasRenderingContext2D, fighter: FighterInstance): void {
+  const { position } = fighter.state;
+  const { arm, colors } = fighter.stats;
+  const weaponHead = getWeaponHeadPosition(fighter);
+  ctx.save();
+  ctx.strokeStyle = "rgba(226, 232, 240, 0.6)";
+  ctx.lineWidth = 5;
+  ctx.beginPath();
+  ctx.moveTo(position.x, position.y);
+  ctx.lineTo(weaponHead.x, weaponHead.y);
+  ctx.stroke();
+
+  ctx.fillStyle = "rgba(248, 113, 113, 0.8)";
+  ctx.beginPath();
+  ctx.arc(weaponHead.x, weaponHead.y, arm.radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = colors.ring;
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawHP(ctx: CanvasRenderingContext2D, fighter: FighterInstance): void {
+  const { position, hp } = fighter.state;
+  const { colors } = fighter.stats;
+  ctx.save();
+  ctx.font = HP_FONT;
+  ctx.fillStyle = colors.text;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.shadowColor = "#000000";
+  ctx.shadowBlur = 6;
+  ctx.fillText(Math.round(hp).toString(), position.x, position.y);
+  ctx.restore();
+}
+
+function drawShield(ctx: CanvasRenderingContext2D, fighter: FighterInstance): void {
+  const { shieldPct, radius } = fighter.stats;
+  if (shieldPct <= 0) {
+    return;
+  }
+  const { position } = fighter.state;
+  ctx.save();
+  ctx.strokeStyle = "rgba(96, 165, 250, 0.35)";
+  ctx.lineWidth = 10;
+  ctx.setLineDash([12, 10]);
+  ctx.beginPath();
+  ctx.arc(position.x, position.y, radius + 12, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawBurnAura(ctx: CanvasRenderingContext2D, fighter: FighterInstance): void {
+  if (!fighter.state.burn) {
+    return;
+  }
+  const { position } = fighter.state;
+  const { radius } = fighter.stats;
+  const time = performance.now() / 120;
+  const alpha = 0.35 + 0.25 * Math.sin(time + fighter.id);
+  ctx.save();
+  ctx.strokeStyle = `rgba(255, 95, 31, ${alpha.toFixed(2)})`;
+  ctx.lineWidth = 14;
+  ctx.shadowBlur = 15;
+  ctx.shadowColor = "rgba(255, 99, 71, 0.8)";
+  ctx.beginPath();
+  ctx.arc(position.x, position.y, radius + 6, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawBottomPanel(ctx: CanvasRenderingContext2D, fighters: FighterInstance[]): void {
+  const panelTop = CANVAS_SIZE - BOTTOM_PANEL_HEIGHT;
+  ctx.save();
+  ctx.fillStyle = PANEL_BACKGROUND;
+  ctx.fillRect(0, panelTop, CANVAS_SIZE, BOTTOM_PANEL_HEIGHT);
+  ctx.strokeStyle = "rgba(148, 163, 184, 0.3)";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(0, panelTop);
+  ctx.lineTo(CANVAS_SIZE, panelTop);
+  ctx.stroke();
+
+  ctx.font = PANEL_FONT;
+  ctx.fillStyle = PANEL_TEXT;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+
+  const padding = 24;
+  const lineHeight = 22;
+  fighters.forEach((fighter, index) => {
+    const lineY = panelTop + padding + index * (lineHeight * 2);
+    ctx.fillStyle = PANEL_TEXT;
+    ctx.font = "600 18px 'Segoe UI', sans-serif";
+    ctx.fillText(fighter.stats.name, padding, lineY);
+    ctx.font = PANEL_FONT;
+    const info = buildStatLine(fighter);
+    ctx.fillText(info, padding, lineY + lineHeight);
+  });
+
+  ctx.font = "500 14px 'Segoe UI', sans-serif";
+  ctx.fillStyle = "#94a3b8";
+  ctx.fillText("Press R to restart", padding, panelTop + BOTTOM_PANEL_HEIGHT - 24);
+  ctx.restore();
+}
+
+function buildStatLine(fighter: FighterInstance): string {
+  const { stats } = fighter;
+  const shieldPct = Math.round(stats.shieldPct * 100);
+  const burn = stats.burnPerTick > 0 ? `${stats.burnPerTick}` : "0";
+  return `DMG: ${stats.baseDamage} | Hellfire: ${stats.hellfireDamage} | Burn DMG: ${burn}/tick | Demon DMG: ${stats.demonDamage} | Shield: ${shieldPct}% | Speed: ${stats.speedMultiplier.toFixed(2)} | Dmg: ${stats.damageMultiplier.toFixed(2)}`;
+}
+
+function drawWinnerText(ctx: CanvasRenderingContext2D, winnerName: string): void {
+  ctx.save();
+  ctx.font = WINNER_FONT;
+  ctx.fillStyle = "#fbbf24";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.shadowColor = "rgba(251, 191, 36, 0.5)";
+  ctx.shadowBlur = 24;
+  ctx.fillText(`${winnerName} Wins!`, CANVAS_SIZE / 2, CANVAS_SIZE / 2);
+  ctx.restore();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: {
+    open: false
+  }
+});


### PR DESCRIPTION
## Summary
- add `npm start` alias and a build-backed `npm test` script so npm users see useful commands when listing scripts
- rewrite the readme with a concise quick-start guide, gameplay overview, and project structure reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d42afbb8248321b81d862795f61956